### PR TITLE
Add Next.js skeleton with SilkHQ components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env.local

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,7 @@
+# Frontend Demo using SilkHQ Components
+
+This demo shows a vertically scrolling feed with large cards similar to a dating app. It relies on SilkHQ web components served from a CDN. A toggle button switches between light and dark themes.
+
+## Running
+
+Open `index.html` in a modern browser. The page loads SilkHQ components from a CDN so internet access is required.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SilkHQ Feed Demo</title>
+    <link id="theme-style" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@silk-ui/theme@latest/dist/light.css">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <button id="theme-toggle" class="toggle">Dark Mode</button>
+    <div id="feed" class="feed"></div>
+
+    <script src="https://cdn.jsdelivr.net/npm/@silk-ui/components@latest/dist/silkhq-components.js"></script>
+    <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,39 @@
+const posts = [
+  { id: 1, text: 'This is a bigger card from SilkHQ components.' },
+  { id: 2, text: 'Cards fill most of the screen like a dating app.' },
+  { id: 3, text: 'You can scroll vertically as you would on Twitter.' }
+];
+
+function renderFeed() {
+  const feed = document.getElementById('feed');
+  feed.innerHTML = '';
+  posts.forEach(post => {
+    const card = document.createElement('silk-card');
+    card.className = 'feed-card';
+    card.textContent = post.text;
+    feed.appendChild(card);
+  });
+}
+
+renderFeed();
+
+const toggleBtn = document.getElementById('theme-toggle');
+
+function setTheme(mode) {
+  const styleTag = document.getElementById('theme-style');
+  if (mode === 'dark') {
+    styleTag.href = 'https://cdn.jsdelivr.net/npm/@silk-ui/theme@latest/dist/dark.css';
+    toggleBtn.textContent = 'Light Mode';
+  } else {
+    styleTag.href = 'https://cdn.jsdelivr.net/npm/@silk-ui/theme@latest/dist/light.css';
+    toggleBtn.textContent = 'Dark Mode';
+  }
+  toggleBtn.dataset.mode = mode;
+}
+
+setTheme('light');
+
+toggleBtn.addEventListener('click', () => {
+  const mode = toggleBtn.dataset.mode === 'light' ? 'dark' : 'light';
+  setTheme(mode);
+});

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,32 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+  background-color: var(--sl-color-bg, #fff);
+  color: var(--sl-color-text, #000);
+}
+
+.feed {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px;
+}
+
+.feed-card {
+  width: 90vw;
+  max-width: 500px;
+  height: 70vh;
+  margin-bottom: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  font-size: 1.25rem;
+}
+
+.toggle {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 100;
+}

--- a/nextjs-app/README.md
+++ b/nextjs-app/README.md
@@ -1,0 +1,29 @@
+# Next.js Demo with SilkHQ, TailwindCSS, and Supabase
+
+This project is a minimal Next.js setup that demonstrates how you might use **SilkHQ** components alongside **TailwindCSS** and **Supabase**.
+
+The dependencies are listed in `package.json` but aren't installed automatically in this environment. You need network access to run `npm install`.
+
+## Running locally
+
+1. Install dependencies (requires internet):
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+## Environment Variables
+
+Create a `.env.local` file with your Supabase keys:
+
+```
+NEXT_PUBLIC_SUPABASE_URL=<url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<key>
+```
+
+## SilkHQ Components
+
+The page loads SilkHQ web components from a CDN. If your environment uses a different URL, update the `<link>` and `<script>` tags in `pages/index.tsx`.

--- a/nextjs-app/lib/supabase.ts
+++ b/nextjs-app/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/nextjs-app/next-env.d.ts
+++ b/nextjs-app/next-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="next" />\n/// <reference types="next/image-types/global" />

--- a/nextjs-app/next.config.js
+++ b/nextjs-app/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/nextjs-app/package.json
+++ b/nextjs-app/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "nextjs-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "@supabase/supabase-js": "latest"
+  },
+  "devDependencies": {
+    "tailwindcss": "latest",
+    "postcss": "latest",
+    "autoprefixer": "latest"
+  }
+}

--- a/nextjs-app/pages/_app.tsx
+++ b/nextjs-app/pages/_app.tsx
@@ -1,0 +1,6 @@
+import '../styles/globals.css'
+import type { AppProps } from 'next/app'
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/nextjs-app/pages/index.tsx
+++ b/nextjs-app/pages/index.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import Head from 'next/head'
+
+const posts = [
+  { id: 1, text: 'This is a bigger card from SilkHQ components.' },
+  { id: 2, text: 'Cards fill most of the screen like a dating app.' },
+  { id: 3, text: 'You can scroll vertically as you would on Twitter.' },
+]
+
+export default function Home() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light')
+
+  useEffect(() => {
+    // load SilkHQ web components
+    const script = document.createElement('script')
+    script.src = 'https://cdn.jsdelivr.net/npm/@silk-ui/components@latest/dist/silkhq-components.js'
+    script.async = true
+    document.body.appendChild(script)
+  }, [])
+
+  const themeHref = theme === 'light'
+    ? 'https://cdn.jsdelivr.net/npm/@silk-ui/theme@latest/dist/light.css'
+    : 'https://cdn.jsdelivr.net/npm/@silk-ui/theme@latest/dist/dark.css'
+
+  return (
+    <>
+      <Head>
+        <title>SilkHQ Feed Demo</title>
+        <link id="theme-style" rel="stylesheet" href={themeHref} />
+      </Head>
+      <button
+        className="fixed top-2 right-2 z-10 px-3 py-1 border rounded"
+        onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+      >
+        {theme === 'light' ? 'Dark Mode' : 'Light Mode'}
+      </button>
+      <div className="flex flex-col items-center p-4 space-y-4">
+        {posts.map(post => (
+          <silk-card
+            key={post.id}
+            class="w-[90vw] max-w-[500px] h-[70vh] flex items-center justify-center text-center text-xl"
+          >
+            {post.text}
+          </silk-card>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/nextjs-app/postcss.config.js
+++ b/nextjs-app/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/nextjs-app/styles/globals.css
+++ b/nextjs-app/styles/globals.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/nextjs-app/tailwind.config.js
+++ b/nextjs-app/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/nextjs-app/tsconfig.json
+++ b/nextjs-app/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- start a Next.js project skeleton using TailwindCSS and Supabase
- wire in SilkHQ components with a theme toggle
- document how to run the Next.js demo
- ignore node build artifacts

## Testing
- `npm test` *(fails: package.json missing)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.